### PR TITLE
Make generally useful JsonServerServlet code public static methods

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,6 +4,20 @@ OVERVIEW
 -----------------------------------------
 Repo for code shared between Java services.
 
+VERSION: 0.0.14 (Released TBD)
+--------------------------------------
+
+NEW FEATURES:
+- None
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Made public static methods in JsonServerServlet for getting the
+  server configuration, getting the IP address to log, and setting up
+  response headers.
+
+ANTICIPATED FUTURE DEVELOPMENTS:
+- None
+
 
 VERSION: 0.0.13 (Released 12/14/2015)
 --------------------------------------

--- a/src/us/kbase/common/awe/test/AwePlaying.java
+++ b/src/us/kbase/common/awe/test/AwePlaying.java
@@ -16,6 +16,7 @@ public class AwePlaying {
 		testTaskHolder();
 	}
 	
+	@SuppressWarnings("unused")
 	private static void testClient() throws Exception {
 		AweClient client = new AweClient(AweClient.DEFAULT_DEV_SERVER_URL);
 		AwfTemplate job = AweClient.createSimpleJobTemplate("protcmp_pipeline", "protcmp", "1 2 3 4 5 6 8", "java_generic_script");

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -72,10 +72,14 @@ public class JsonServerServlet extends HttpServlet {
 	private JsonServerSyslog userLogger;
 	
 	/** The key for the environment variable or JVM variable with the value of
-	 * server config file location.
+	 * the server config file location.
 	 */
 	public static final String KB_DEP = "KB_DEPLOYMENT_CONFIG";
-	final private static String KB_SERVNAME = "KB_SERVICE_NAME";
+	
+	/** The key for the environment variable or JVM variable with the value of
+	 * the server name.
+	 */
+	public static final String KB_SERVNAME = "KB_SERVICE_NAME";
 	private static final String CONFIG_AUTH_SERVICE_URL_PARAM = "auth-service-url";
 	private static final String KB_JOB_SERVICE_URL = "KB_JOB_SERVICE_URL";
 	private static final String CONFIG_JOB_SERVICE_URL_PARAM = "job-service-url";
@@ -178,10 +182,12 @@ public class JsonServerServlet extends HttpServlet {
 	public static Map<String, String> getConfig(
 			final String defaultServiceName,
 			final JsonServerSyslog logger) {
+		if (logger == null) {
+			throw new NullPointerException("logger cannot be null");
+		}
 		final String serviceName = getServiceName(defaultServiceName);
 		final String file = System.getProperty(KB_DEP) == null ?
 				System.getenv(KB_DEP) : System.getProperty(KB_DEP);
-		//read the config file
 		if (file == null) {
 			return new HashMap<String, String>();
 		}
@@ -206,6 +212,9 @@ public class JsonServerServlet extends HttpServlet {
 	}
 
 	private static String getServiceName(final String defaultServiceName) {
+		if (defaultServiceName == null) {
+			throw new NullPointerException("service name cannot be null");
+		}
 		String serviceName = System.getProperty(KB_SERVNAME) == null ?
 				System.getenv(KB_SERVNAME) : System.getProperty(KB_SERVNAME);
 		if (serviceName == null) {
@@ -290,8 +299,8 @@ public class JsonServerServlet extends HttpServlet {
 	 * * Sets HTTP_ACCESS_CONTROL_REQUEST_HEADERS to the contents of the
 	 * request Access-Control-Allow-Headers, or a minimum of "authorization"
 	 * * Sets the content type to application/json
-	 * @param request
-	 * @param response
+	 * @param request the HTTP request
+	 * @param response the HTTP response
 	 */
 	public static void setupResponseHeaders(HttpServletRequest request, HttpServletResponse response) {
 		response.setHeader("Access-Control-Allow-Origin", "*");

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -56,6 +56,8 @@ public class JsonServerServlet extends HttpServlet {
 	private static final String APP_JSON = "application/json";
 	private static final String DONT_TRUST_X_IP_HEADERS =
 			"dont_trust_x_ip_headers";
+	private static final String DONT_TRUST_X_IP_HEADERS2 =
+			"dont-trust-x-ip-headers";
 	private static final String STRING_TRUE = "true";
 	private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final String X_REAL_IP = "X-Real-IP";
@@ -68,10 +70,14 @@ public class JsonServerServlet extends HttpServlet {
 	public static final int LOG_LEVEL_DEBUG3 = JsonServerSyslog.LOG_LEVEL_DEBUG + 2;
 	private JsonServerSyslog sysLogger;
 	private JsonServerSyslog userLogger;
-	final private static String KB_DEP = "KB_DEPLOYMENT_CONFIG";
+	
+	/** The key for the environment variable or JVM variable with the value of
+	 * server config file location.
+	 */
+	public static final String KB_DEP = "KB_DEPLOYMENT_CONFIG";
 	final private static String KB_SERVNAME = "KB_SERVICE_NAME";
-    private static final String CONFIG_AUTH_SERVICE_URL_PARAM = "auth-service-url";
-    private static final String KB_JOB_SERVICE_URL = "KB_JOB_SERVICE_URL";
+	private static final String CONFIG_AUTH_SERVICE_URL_PARAM = "auth-service-url";
+	private static final String KB_JOB_SERVICE_URL = "KB_JOB_SERVICE_URL";
 	private static final String CONFIG_JOB_SERVICE_URL_PARAM = "job-service-url";
 	protected Map<String, String> config = new HashMap<String, String>();
 	private Server jettyServer = null;
@@ -129,12 +135,16 @@ public class JsonServerServlet extends HttpServlet {
 		
 	}
 	
+	/** Sets the server to failed mode. All API calls will return an error. */
 	public void startupFailed() {
 		this.startupFailed = true;
 	}
 	
+	/** Create a new Servlet.
+	 * @param specServiceName the name of this server.
+	 */
 	public JsonServerServlet(String specServiceName) {
-	    this.specServiceName = specServiceName;
+		this.specServiceName = specServiceName;
 		this.mapper = new ObjectMapper().registerModule(new JacksonTupleModule());
 		this.rpcCache = new HashMap<String, Method>();
 		for (Method m : getClass().getMethods()) {
@@ -142,42 +152,69 @@ public class JsonServerServlet extends HttpServlet {
 				JsonServerMethod ann = m.getAnnotation(JsonServerMethod.class);
 				rpcCache.put(ann.rpc(), m);
 				if (ann.async()) {
-	                rpcCache.put(ann.rpc() + "_async", m);
-                    rpcCache.put(ann.rpc() + "_check", m);
+					rpcCache.put(ann.rpc() + "_async", m);
+					rpcCache.put(ann.rpc() + "_check", m);
 				}
 			}
 		}
 		
-		String serviceName = System.getProperty(KB_SERVNAME) == null ?
-				System.getenv(KB_SERVNAME) : System.getProperty(KB_SERVNAME);
-		if (serviceName == null) {
-			serviceName = specServiceName;
-			if (serviceName.contains(":"))
-				serviceName = serviceName.substring(0, serviceName.indexOf(':')).trim();
-		}
-		String file = System.getProperty(KB_DEP) == null ?
-				System.getenv(KB_DEP) : System.getProperty(KB_DEP);
-		sysLogger = new JsonServerSyslog(serviceName, KB_DEP, LOG_LEVEL_INFO);
+		sysLogger = new JsonServerSyslog(getServiceName(specServiceName),
+				KB_DEP, LOG_LEVEL_INFO);
 		userLogger = new JsonServerSyslog(sysLogger);
+		config = getConfig(specServiceName, sysLogger);
+	}
+	
+	/**
+	 * Returns the configuration from the KBase deploy.cfg config file.
+	 * Returns an empty map if no config file is specified, if the file
+	 * can't be read, or if there is no section of the config file matching
+	 * serviceName.
+	 * @param defaultServiceName the default name of the service to use if it
+	 * can't be found in the environment, and the section of the config file
+	 * where the service's configuration exists
+	 * @param logger a logger for logging errors
+	 * @return the server config from the deploy.cfg file
+	 */
+	public static Map<String, String> getConfig(
+			final String defaultServiceName,
+			final JsonServerSyslog logger) {
+		final String serviceName = getServiceName(defaultServiceName);
+		final String file = System.getProperty(KB_DEP) == null ?
+				System.getenv(KB_DEP) : System.getProperty(KB_DEP);
 		//read the config file
 		if (file == null) {
-			return;
+			return new HashMap<String, String>();
 		}
-		File deploy = new File(file);
-		Ini ini = null;
+		final File deploy = new File(file);
+		final Ini ini;
 		try {
 			ini = new Ini(deploy);
 		} catch (IOException ioe) {
-			sysLogger.log(LOG_LEVEL_ERR, getClass().getName(), "There was an IO Error reading the deploy file "
+			logger.log(LOG_LEVEL_ERR, JsonServerServlet.class.getName(),
+					"There was an IO Error reading the deploy file "
 							+ deploy + ". Traceback:\n" + ioe);
-			return;
+			return new HashMap<String, String>();
 		}
-		config = ini.get(serviceName);
+		Map<String, String> config = ini.get(serviceName);
 		if (config == null) {
 			config = new HashMap<String, String>();
-			sysLogger.log(LOG_LEVEL_ERR, getClass().getName(), "The configuration file " + deploy + 
-							" has no section " + serviceName);
+			logger.log(LOG_LEVEL_ERR, JsonServerServlet.class.getName(),
+					"The configuration file " + deploy + " has no section " +
+			serviceName);
 		}
+		return config;
+	}
+
+	private static String getServiceName(final String defaultServiceName) {
+		String serviceName = System.getProperty(KB_SERVNAME) == null ?
+				System.getenv(KB_SERVNAME) : System.getProperty(KB_SERVNAME);
+		if (serviceName == null) {
+			serviceName = defaultServiceName;
+			if (serviceName.contains(":"))
+				serviceName = serviceName.substring(
+						0, serviceName.indexOf(':')).trim();
+		}
+		return serviceName;
 	}
 
 	/**
@@ -237,9 +274,9 @@ public class JsonServerServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		JsonServerSyslog.RpcInfo info = JsonServerSyslog.getCurrentRpcInfo().reset();
-		info.setIp(request.getRemoteAddr());
+		info.setIp(getIpAddress(request, config));
 		response.setContentType(APP_JSON);
-		OutputStream output	= response.getOutputStream();
+		OutputStream output = response.getOutputStream();
 		JsonServerSyslog.getCurrentRpcInfo().reset();
 		if (startupFailed) {
 			writeError(wrap(response), -32603, "The server did not start up properly. Please check the log files for the cause.", output);
@@ -248,7 +285,15 @@ public class JsonServerServlet extends HttpServlet {
 		writeError(wrap(response), -32300, "HTTP GET not allowed.", output);
 	}
 
-	private void setupResponseHeaders(HttpServletRequest request, HttpServletResponse response) {
+	/** Set up server response headers.
+	 * * Sets Access-Control-Allow-Origin: *
+	 * * Sets HTTP_ACCESS_CONTROL_REQUEST_HEADERS to the contents of the
+	 * request Access-Control-Allow-Headers, or a minimum of "authorization"
+	 * * Sets the content type to application/json
+	 * @param request
+	 * @param response
+	 */
+	public static void setupResponseHeaders(HttpServletRequest request, HttpServletResponse response) {
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		String allowedHeaders = request.getHeader("HTTP_ACCESS_CONTROL_REQUEST_HEADERS");
 		response.setHeader("Access-Control-Allow-Headers", allowedHeaders == null ? "authorization" : allowedHeaders);
@@ -258,15 +303,15 @@ public class JsonServerServlet extends HttpServlet {
 	@Override
 	protected void doPost(HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 		checkMemoryForRpc();
-		String remoteIp = getIpAddress(request);
-        setupResponseHeaders(request, response);
-        OutputStream output = response.getOutputStream();
-        ResponseStatusSetter respStatus = new ResponseStatusSetter() {
-            @Override
-            public void setStatus(int status) {
-                response.setStatus(status);
-            }
-        };
+		String remoteIp = getIpAddress(request, config);
+		setupResponseHeaders(request, response);
+		OutputStream output = response.getOutputStream();
+		ResponseStatusSetter respStatus = new ResponseStatusSetter() {
+			@Override
+			public void setStatus(int status) {
+				response.setStatus(status);
+			}
+		};
 		JsonServerSyslog.RpcInfo info = JsonServerSyslog.getCurrentRpcInfo().reset();
 		info.setIp(remoteIp);
 		JsonTokenStream jts = null; 
@@ -594,11 +639,24 @@ public class JsonServerServlet extends HttpServlet {
 		}
 	}
 
-	private String getIpAddress(HttpServletRequest request) {
+	/** Get the IP address of the client. In order of precedence:
+	 * 1. The first address in X-Forwarded-For
+	 * 2. X-Real-IP
+	 * 3. The remote address.
+	 * If dont_trust_x_ip_headers or dont-trust-x-ip-headers is set to "true"
+	 * in the configuration, the remote address is returned.
+	 * @param request the HTTP request
+	 * @param config the server configuration as returned by getConfig().
+	 * @return the IP address of the client.
+	 */
+	public static String getIpAddress(
+			final HttpServletRequest request,
+			final Map<String, String> config) {
 		final String xFF = request.getHeader(X_FORWARDED_FOR);
 		final String realIP = request.getHeader(X_REAL_IP);
-		final boolean trustXHeaders = !STRING_TRUE.equals(
-				config.get(DONT_TRUST_X_IP_HEADERS));
+		final boolean trustXHeaders =
+				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS)) &&
+				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS2));
 		
 		if (trustXHeaders) {
 			if (xFF != null && !xFF.isEmpty()) {

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -206,7 +206,7 @@ public class JsonServerServlet extends HttpServlet {
 			config = new HashMap<String, String>();
 			logger.log(LOG_LEVEL_ERR, JsonServerServlet.class.getName(),
 					"The configuration file " + deploy + " has no section " +
-			serviceName);
+					serviceName);
 		}
 		return config;
 	}

--- a/src/us/kbase/common/service/JsonServerSyslog.java
+++ b/src/us/kbase/common/service/JsonServerSyslog.java
@@ -53,6 +53,7 @@ public class JsonServerSyslog {
 		this(serviceName, configFileParam, -1);
 	}
 	
+	//TODO the interface here would more general if it just took a file and a log level, make the client class figure out the file path
 	public JsonServerSyslog(String serviceName, String configFileParam, int defultLogLevel) {
 		this.serviceName = serviceName;
 		logLevel = defultLogLevel;

--- a/src/us/kbase/common/service/JsonServerSyslog.java
+++ b/src/us/kbase/common/service/JsonServerSyslog.java
@@ -184,7 +184,7 @@ public class JsonServerSyslog {
 		throw new IllegalStateException();
 	}
 
-	static RpcInfo getCurrentRpcInfo() {
+	public static RpcInfo getCurrentRpcInfo() {
 		RpcInfo ret = rpcInfo.get();
 		if (ret == null) {
 			ret = new RpcInfo();
@@ -369,43 +369,43 @@ public class JsonServerSyslog {
 			return this;
 		}
 		
-		String getId() {
+		public String getId() {
 			return id;
 		}
 		
-		void setId(String id) {
+		public void setId(String id) {
 			this.id = id;
 		}
 		
-		String getModule() {
+		public String getModule() {
 			return module;
 		}
 		
-		void setModule(String module) {
+		public void setModule(String module) {
 			this.module = module;
 		}
 		
-		String getMethod() {
+		public String getMethod() {
 			return method;
 		}
 		
-		void setMethod(String method) {
+		public void setMethod(String method) {
 			this.method = method;
 		}
 		
-		String getUser() {
+		public String getUser() {
 			return user;
 		}
 		
-		void setUser(String user) {
+		public void setUser(String user) {
 			this.user = user;
 		}
 		
-		String getIp() {
+		public String getIp() {
 			return ip;
 		}
 		
-		void setIp(String ip) {
+		public void setIp(String ip) {
 			this.ip = ip;
 		}
 	}

--- a/src/us/kbase/common/service/test/HttpServletRequestMock.java
+++ b/src/us/kbase/common/service/test/HttpServletRequestMock.java
@@ -191,7 +191,7 @@ public class HttpServletRequestMock implements HttpServletRequest {
 
 	@Override
 	public Cookie[] getCookies() {
-		return null;
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/us/kbase/common/service/test/HttpServletRequestMock.java
+++ b/src/us/kbase/common/service/test/HttpServletRequestMock.java
@@ -20,6 +20,11 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 public class HttpServletRequestMock implements HttpServletRequest {
 
 	private Map<String, String> headers = new HashMap<String, String>();
+	private String ipAddress = null;
+	
+	public void setIpAddress(String ip) {
+		ipAddress = ip;
+	}
 	
 	public void setHeader(String key, String value) {
 		headers.put(key, value);
@@ -121,7 +126,7 @@ public class HttpServletRequestMock implements HttpServletRequest {
 
 	@Override
 	public String getRemoteAddr() {
-		throw new NotImplementedException();
+		return ipAddress;
 	}
 
 	@Override

--- a/src/us/kbase/common/service/test/HttpServletRequestMock.java
+++ b/src/us/kbase/common/service/test/HttpServletRequestMock.java
@@ -15,8 +15,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 public class HttpServletRequestMock implements HttpServletRequest {
 
 	private Map<String, String> headers = new HashMap<String, String>();
@@ -32,96 +30,96 @@ public class HttpServletRequestMock implements HttpServletRequest {
 	
 	@Override
 	public Object getAttribute(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Enumeration getAttributeNames() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getCharacterEncoding() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getContentLength() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getContentType() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletInputStream getInputStream() throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getLocalAddr() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getLocalName() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getLocalPort() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public Locale getLocale() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Enumeration getLocales() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getParameter(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Map getParameterMap() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Enumeration getParameterNames() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String[] getParameterValues(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getProtocol() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public BufferedReader getReader() throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getRealPath(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -131,64 +129,64 @@ public class HttpServletRequestMock implements HttpServletRequest {
 
 	@Override
 	public String getRemoteHost() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getRemotePort() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public RequestDispatcher getRequestDispatcher(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getScheme() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getServerName() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getServerPort() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isSecure() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void removeAttribute(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 		
 	}
 
 	@Override
 	public void setAttribute(String arg0, Object arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setCharacterEncoding(String arg0)
 			throws UnsupportedEncodingException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getAuthType() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getContextPath() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -198,7 +196,7 @@ public class HttpServletRequestMock implements HttpServletRequest {
 
 	@Override
 	public long getDateHeader(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -209,102 +207,102 @@ public class HttpServletRequestMock implements HttpServletRequest {
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Enumeration getHeaderNames() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Enumeration getHeaders(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getIntHeader(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getMethod() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getPathInfo() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getPathTranslated() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getQueryString() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getRemoteUser() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getRequestURI() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public StringBuffer getRequestURL() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getRequestedSessionId() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getServletPath() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public HttpSession getSession() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public HttpSession getSession(boolean arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public Principal getUserPrincipal() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isRequestedSessionIdFromCookie() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isRequestedSessionIdFromURL() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isRequestedSessionIdFromUrl() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isRequestedSessionIdValid() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isUserInRole(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/us/kbase/common/service/test/HttpServletRequestMock.java
+++ b/src/us/kbase/common/service/test/HttpServletRequestMock.java
@@ -1,0 +1,305 @@
+package us.kbase.common.service.test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class HttpServletRequestMock implements HttpServletRequest {
+
+	private Map<String, String> headers = new HashMap<String, String>();
+	
+	public void setHeader(String key, String value) {
+		headers.put(key, value);
+	}
+	
+	@Override
+	public Object getAttribute(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getAttributeNames() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getContentLength() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getContentType() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getLocalAddr() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getLocalName() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getLocalPort() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public Locale getLocale() {
+		throw new NotImplementedException();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getLocales() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getParameter(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Map getParameterMap() {
+		throw new NotImplementedException();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getParameterNames() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String[] getParameterValues(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getProtocol() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRealPath(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRemoteAddr() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRemoteHost() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getRemotePort() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public RequestDispatcher getRequestDispatcher(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getScheme() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getServerName() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getServerPort() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isSecure() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void removeAttribute(String arg0) {
+		throw new NotImplementedException();
+		
+	}
+
+	@Override
+	public void setAttribute(String arg0, Object arg1) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setCharacterEncoding(String arg0)
+			throws UnsupportedEncodingException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getAuthType() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getContextPath() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public Cookie[] getCookies() {
+		return null;
+	}
+
+	@Override
+	public long getDateHeader(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getHeader(String header) {
+		return headers.get(header);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getHeaderNames() {
+		throw new NotImplementedException();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Enumeration getHeaders(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getIntHeader(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getMethod() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getPathInfo() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getPathTranslated() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getQueryString() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRemoteUser() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRequestURI() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public StringBuffer getRequestURL() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getRequestedSessionId() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getServletPath() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public HttpSession getSession() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public HttpSession getSession(boolean arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public Principal getUserPrincipal() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromCookie() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromURL() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromUrl() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isRequestedSessionIdValid() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isUserInRole(String arg0) {
+		throw new NotImplementedException();
+	}
+}

--- a/src/us/kbase/common/service/test/HttpServletResponseMock.java
+++ b/src/us/kbase/common/service/test/HttpServletResponseMock.java
@@ -1,0 +1,184 @@
+package us.kbase.common.service.test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class HttpServletResponseMock implements HttpServletResponse {
+
+	private Map<String, String> headers = new HashMap<String, String>();
+	private String contentType = null;
+	
+	public String getHeader(String header) {
+		return headers.get(header);
+	}
+	
+	@Override
+	public void flushBuffer() throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int getBufferSize() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String getContentType() {
+		return contentType;
+	}
+
+	@Override
+	public Locale getLocale() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public ServletOutputStream getOutputStream() throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public PrintWriter getWriter() throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean isCommitted() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void reset() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void resetBuffer() {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setBufferSize(int arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setCharacterEncoding(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setContentLength(int arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	@Override
+	public void setLocale(Locale arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void addCookie(Cookie arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void addDateHeader(String arg0, long arg1) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void addHeader(String key, String value) {
+		headers.put(key, value);
+	}
+
+	@Override
+	public void addIntHeader(String arg0, int arg1) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public boolean containsHeader(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String encodeRedirectURL(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String encodeRedirectUrl(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String encodeURL(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public String encodeUrl(String arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void sendError(int arg0) throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void sendError(int arg0, String arg1) throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void sendRedirect(String arg0) throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setDateHeader(String arg0, long arg1) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setHeader(String key, String value) {
+		headers.put(key, value);
+	}
+
+	@Override
+	public void setIntHeader(String arg0, int arg1) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setStatus(int arg0) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void setStatus(int arg0, String arg1) {
+		throw new NotImplementedException();
+	}
+
+}

--- a/src/us/kbase/common/service/test/HttpServletResponseMock.java
+++ b/src/us/kbase/common/service/test/HttpServletResponseMock.java
@@ -10,8 +10,6 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 public class HttpServletResponseMock implements HttpServletResponse {
 
 	private Map<String, String> headers = new HashMap<String, String>();
@@ -23,17 +21,17 @@ public class HttpServletResponseMock implements HttpServletResponse {
 	
 	@Override
 	public void flushBuffer() throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public int getBufferSize() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String getCharacterEncoding() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -43,47 +41,47 @@ public class HttpServletResponseMock implements HttpServletResponse {
 
 	@Override
 	public Locale getLocale() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ServletOutputStream getOutputStream() throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public PrintWriter getWriter() throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean isCommitted() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void reset() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void resetBuffer() {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setBufferSize(int arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setCharacterEncoding(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setContentLength(int arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -93,17 +91,17 @@ public class HttpServletResponseMock implements HttpServletResponse {
 
 	@Override
 	public void setLocale(Locale arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void addCookie(Cookie arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void addDateHeader(String arg0, long arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -113,52 +111,52 @@ public class HttpServletResponseMock implements HttpServletResponse {
 
 	@Override
 	public void addIntHeader(String arg0, int arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean containsHeader(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String encodeRedirectURL(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String encodeRedirectUrl(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String encodeURL(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public String encodeUrl(String arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void sendError(int arg0) throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void sendError(int arg0, String arg1) throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void sendRedirect(String arg0) throws IOException {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setDateHeader(String arg0, long arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -168,17 +166,17 @@ public class HttpServletResponseMock implements HttpServletResponse {
 
 	@Override
 	public void setIntHeader(String arg0, int arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setStatus(int arg0) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void setStatus(int arg0, String arg1) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
+++ b/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
@@ -2,15 +2,28 @@ package us.kbase.common.service.test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
 import org.junit.Test;
+import org.productivity.java.syslog4j.SyslogIF;
 
 import us.kbase.common.service.JsonServerServlet;
+import us.kbase.common.service.JsonServerSyslog;
+import us.kbase.common.service.JsonServerSyslog.SyslogOutput;
 
-/** Tests some new public static methods that can be reused in other services.
+/** Tests some new public static methods in JsonServerServlet that can be
+ *  reused in other services.
  * @author gaprice@lbl.gov
  *
  */
@@ -64,11 +77,213 @@ public class JsonServerServletPublicMethodsTest {
 				req, config), is("000.000.000.001"));
 	}
 	
-	@Test
-	public void getConfig() throws Exception {
-		//TODO TEST getConfig()
+	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
+	@SuppressWarnings("unchecked")
+	private static Map<String, String> getenv() throws Exception {
+		Map<String, String> unmodifiable = System.getenv();
+		Class<?> cu = unmodifiable.getClass();
+		Field m = cu.getDeclaredField("m");
+		m.setAccessible(true);
+		return (Map<String, String>) m.get(unmodifiable);
 	}
 	
+	private static Path createTempFile() throws Exception {
+		Path f = Files.createTempFile(
+				"JsonServerServletPublicMethodsTest", "tempfile",
+				PosixFilePermissions.asFileAttribute(
+						PosixFilePermissions.fromString("rwx------")));
+		f.toFile().deleteOnExit();
+		return f;
+	}
+	
+	class SysLogOutputMock extends SyslogOutput {
+		
+		public int lastSysLogInt = -1;
+//		public int lastFileInt = -1;
+		public String lastSysLogMsg = null;
+//		public String lastFileMsg = null;
+		
+		@Override
+		public void logToSystem(SyslogIF log, int level, String message) {
+			lastSysLogInt = level;
+			lastSysLogMsg = message;
+		}
+		
+		@Override
+		public PrintWriter logToFile(File f, PrintWriter pw, int level,
+				String message) throws Exception {
+			throw new UnsupportedOperationException();
+//			lastFileInt = level;
+//			lastFileMsg = message;
+//			return null;
+		}
+		
+		public void reset() {
+			lastSysLogInt = -1;
+			lastSysLogMsg = null;
+		}
+	}
+
+	@Test
+	public void getConfig() throws Exception {
+
+		//set up config result maps
+		Map<String, String> empty = new HashMap<String, String>();
+		Map<String, String> expect = new HashMap<String, String>();
+		expect.put("somekey", "somevalue");
+		
+		//set up ini file
+		Path temp = createTempFile();
+		Ini ini = new Ini(temp.toFile());
+		Section sec = ini.add("ServerSection");
+		sec.add("somekey", "somevalue");
+		ini.store();
+
+		//possible error strings
+		String[] noFileErr = new String[2];
+		noFileErr[0] = 
+				"There was an IO Error reading the deploy file somenonexistantfilewhichshouldntexist. Traceback:\njava.io.FileNotFoundException:";
+		noFileErr[1] = 
+			"somenonexistantfilewhichshouldntexist (No such file or directory)";
+		String[] noSecErr = new String[2];
+		noSecErr[0] =  "The configuration file ";
+		noSecErr[1] =  " has no section BadServerSection";
+		
+		//set up the logger and mock output
+		JsonServerSyslog log = new JsonServerSyslog("foo", "foo");
+		SysLogOutputMock mockout = new SysLogOutputMock();
+		log.changeOutput(mockout);
+		
+		//test with null args
+		try {
+			JsonServerServlet.getConfig(null, log);
+			fail("got config with null servername");
+		} catch (NullPointerException npe) {
+			assertThat("correct exception messsage", npe.getLocalizedMessage(),
+					is("service name cannot be null"));
+		}
+		try {
+			JsonServerServlet.getConfig("thing", null);
+			fail("got config with null logger");
+		} catch (NullPointerException npe) {
+			assertThat("correct exception messsage", npe.getLocalizedMessage(),
+					is("logger cannot be null"));
+		}
+		
+		// test with no file specified in env or sys props
+		Map<String, String> cfg = JsonServerServlet.getConfig("foo", log);
+		
+		assertThat("empty config", cfg, is(empty));
+		assertThat("no logged error", mockout.lastSysLogInt,
+				is(-1));
+		assertThat("no logged message", mockout.lastSysLogMsg,
+				is((String) null));
+		
+		// test with bad filename, set in sysprops in this case
+		mockout.reset();
+		System.getProperties().setProperty(JsonServerServlet.KB_DEP,
+				"somenonexistantfilewhichshouldntexist");
+		
+		cfg = JsonServerServlet.getConfig("foo", log);
+		
+		assertThat("empty config", cfg, is(empty));
+		assertThat("logged error correct", mockout.lastSysLogInt,
+				is(JsonServerServlet.LOG_LEVEL_ERR));
+		checkSyslogMsg(mockout.lastSysLogMsg, noFileErr[0], noFileErr[1]);
+		
+		//test with good file set in sys props
+		mockout.reset();
+		System.getProperties().setProperty(JsonServerServlet.KB_DEP,
+				temp.toAbsolutePath().toString());
+		
+		cfg = JsonServerServlet.getConfig("ServerSection", log);
+		
+		assertThat("correct config", cfg, is(expect));
+		assertThat("no logged error", mockout.lastSysLogInt, is(-1));
+		assertThat("no logged msg", mockout.lastSysLogMsg, is((String) null));
+		System.getProperties().remove(JsonServerServlet.KB_DEP);
+		
+		//test with good file set in env
+		//also test trimming server name
+		mockout.reset();
+		getenv().put(JsonServerServlet.KB_DEP, temp.toAbsolutePath().toString());
+		
+		cfg = JsonServerServlet.getConfig("ServerSection:somestuff", log);
+		
+		assertThat("correct config", cfg, is(expect));
+		assertThat("no logged error", mockout.lastSysLogInt, is(-1));
+		assertThat("no logged msg", mockout.lastSysLogMsg, is((String) null));
+		
+		//test with a bad servername, file still set in env
+		mockout.reset();
+		
+		cfg = JsonServerServlet.getConfig("BadServerSection", log);
+		
+		assertThat("correct config", cfg, is(empty));
+		assertThat("logged error correct", mockout.lastSysLogInt,
+				is(JsonServerServlet.LOG_LEVEL_ERR));
+		checkSyslogMsg(mockout.lastSysLogMsg,
+				noSecErr[0] + temp.toAbsolutePath().toString(), noSecErr[1]);
+		
+		//test with servername set in sysprops, file still set in env
+		mockout.reset();
+		System.getProperties().setProperty(JsonServerServlet.KB_SERVNAME, "ServerSection");
+
+		cfg = JsonServerServlet.getConfig("BadServerSection", log);
+		
+		assertThat("correct config", cfg, is(expect));
+		assertThat("no logged error", mockout.lastSysLogInt, is(-1));
+		assertThat("no logged msg", mockout.lastSysLogMsg, is((String) null));
+		System.getProperties().remove(JsonServerServlet.KB_SERVNAME);
+		
+		//test with servername set in env, file still set in env
+		mockout.reset();
+		getenv().put(JsonServerServlet.KB_SERVNAME, "ServerSection");
+		
+		cfg = JsonServerServlet.getConfig("BadServerSection", log);
+		
+		assertThat("correct config", cfg, is(expect));
+		assertThat("no logged error", mockout.lastSysLogInt, is(-1));
+		assertThat("no logged msg", mockout.lastSysLogMsg, is((String) null));
+		getenv().remove(JsonServerServlet.KB_SERVNAME);
+		
+	}
+	
+	@SuppressWarnings("unused")
+	private void printArray(String[] array) {
+		for (int i = 0; i < array.length; i++) {
+			System.out.println(array[i]);
+		}
+	}
+	
+	private void checkSyslogMsg(String lastSysLogMsg, String prefix, String suffix) {
+		String[] parts = lastSysLogMsg.split(":", 2);
+		String[] headerParts = parts[0].split("]\\s*\\[");
+		assertThat("server name correct", headerParts[0].substring(1),
+				is("foo"));
+		assertThat("record type correct", headerParts[1], is("ERR"));
+		//2 is timestamp
+		//3 is user running the service
+		assertThat("caller correct", headerParts[4],
+				is("us.kbase.common.service.JsonServerServlet"));
+		//5 is pid
+		assertThat("ip correct", headerParts[6], is("-"));
+		assertThat("remote user correct", headerParts[7], is("-"));
+		assertThat("module correct", headerParts[8], is("-"));
+		assertThat("method correct", headerParts[9], is("-"));
+		assertThat("call ID correct", headerParts[10].substring(
+				0, headerParts[10].length() -1), is("-"));
+		
+		
+//		System.out.println(parts[1]);
+//		System.out.println(prefix);
+//		System.out.println(suffix);
+		assertThat("message prefix correct",
+				parts[1].trim().startsWith(prefix), is (true));
+		assertThat("message suffix correct",
+				parts[1].trim().endsWith(suffix), is (true));
+	}
+
 	@Test
 	public void setUpResponseHeaders() throws Exception {
 		

--- a/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
+++ b/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
@@ -3,6 +3,9 @@ package us.kbase.common.service.test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 import us.kbase.common.service.JsonServerServlet;
@@ -15,7 +18,50 @@ public class JsonServerServletPublicMethodsTest {
 
 	@Test
 	public void ipAddress() throws Exception {
+		Map<String, String> config = new HashMap<String, String>();
+		HttpServletRequestMock req = new HttpServletRequestMock();
+		req.setIpAddress("000.000.000.001");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
 		
+		req.setHeader("X-Real-IP", "");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
+		
+		req.setHeader("X-Real-IP", "000.000.000.002");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.002"));
+		
+		req.setHeader("X-Forwarded-For", "");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.002"));
+		
+		req.setHeader("X-Forwarded-For", "000.000.000.003 , somecrap");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.003"));
+		
+		config.put("dont_trust_x_ip_headers", "false");
+		config.put("dont-trust-x-ip-headers", "tru");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.003"));
+		
+		config.put("dont-trust-x-ip-headers", "true");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
+		
+		config.put("dont_trust_x_ip_headers", "true");
+		config.put("dont-trust-x-ip-headers", "tru");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
+		
+		config.remove("X-Forwarded-For");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
+		
+		config.put("dont_trust_x_ip_headers", "tru");
+		config.put("dont-trust-x-ip-headers", "true");
+		assertThat("correct IP address", JsonServerServlet.getIpAddress(
+				req, config), is("000.000.000.001"));
 	}
 	
 	@Test

--- a/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
+++ b/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
@@ -1,0 +1,56 @@
+package us.kbase.common.service.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import us.kbase.common.service.JsonServerServlet;
+
+/** Tests some new public static methods that can be reused in other services.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class JsonServerServletPublicMethodsTest {
+
+	@Test
+	public void ipAddress() throws Exception {
+		
+	}
+	
+	@Test
+	public void getConfig() throws Exception {
+		
+	}
+	
+	@Test
+	public void setUpResponseHeaders() throws Exception {
+		
+		//test with allowed headers set
+		HttpServletRequestMock req = new HttpServletRequestMock();
+		req.setHeader("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "aHeader");
+		HttpServletResponseMock res = new HttpServletResponseMock();
+		JsonServerServlet.setupResponseHeaders(req, res);
+		
+		assertThat("correct access control origin",
+				res.getHeader("Access-Control-Allow-Origin"), is("*"));
+		assertThat("correct content type", res.getContentType(),
+				is("application/json"));
+		assertThat("correct access control origin",
+				res.getHeader("Access-Control-Allow-Headers"), is("aHeader"));
+
+		
+		//test without allowed headers set
+		req = new HttpServletRequestMock();
+		res = new HttpServletResponseMock();
+		JsonServerServlet.setupResponseHeaders(req, res);
+		assertThat("correct access control origin",
+				res.getHeader("Access-Control-Allow-Origin"), is("*"));
+		assertThat("correct content type", res.getContentType(),
+				is("application/json"));
+		assertThat("correct access control origin",
+				res.getHeader("Access-Control-Allow-Headers"),
+				is("authorization"));
+	}
+	
+}

--- a/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
+++ b/src/us/kbase/common/service/test/JsonServerServletPublicMethodsTest.java
@@ -66,7 +66,7 @@ public class JsonServerServletPublicMethodsTest {
 	
 	@Test
 	public void getConfig() throws Exception {
-		
+		//TODO TEST getConfig()
 	}
 	
 	@Test


### PR DESCRIPTION
Several bits of code in JsonServerServlet are useful for other servlets running alongside the Json servlet in a WAR file, namely

* getting the configuration
* getting the IP address to log
* setting up the response headers.

Made public static methods for this code.

Also made KB_DEP and KB_SERVICENAME constants public.

Might want to consider moving these and other methods into a ServerUtils class or something in the future; not important for now.

