### PR TITLE
Fix logging bug with auth startup.

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,6 +4,14 @@ OVERVIEW
 -----------------------------------------
 Repo for code shared between Java services.
 
+VERSION: 0.0.22 (Released 9/15/2016)
+--------------------------------------
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+- Fixed a bug that would throw an IllegalStateError when configuration of the
+  authentication client in JsonServerServlet failed rather than logging the
+  error.
+
 VERSION: 0.0.21 (Released 8/26/2016)
 --------------------------------------
 

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -188,8 +188,9 @@ public class JsonServerServlet extends HttpServlet {
 				c.withKBaseAuthServerURL(new URL(authURL));
 			} catch (URISyntaxException | MalformedURLException e) {
 				startupFailed();
-				sysLogger.logErr(String.format(
-						"Authentication url %s is invalid", authURL));
+				sysLogger.log(LOG_LEVEL_ERR, getClass().getName(),
+						String.format(
+								"Authentication url %s is invalid", authURL));
 				return null;
 			}
 		}
@@ -197,7 +198,8 @@ public class JsonServerServlet extends HttpServlet {
 			return new ConfigurableAuthService(c);
 		} catch (IOException e) {
 			startupFailed();
-			sysLogger.logErr("Couldn't connect to authentication service at " +
+			sysLogger.log(LOG_LEVEL_ERR, getClass().getName(),
+					"Couldn't connect to authentication service at " +
 					c.getAuthServerURL() + " : " + e.getLocalizedMessage());
 			return null;
 		}


### PR DESCRIPTION
Logger failed to find calling class.

Tested with UJS startup.