### PR TITLE
Add constructor to JsonServerServlet for embedding purposes

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -36,5 +36,10 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/joda/joda-time-2.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/kbase/auth/kbase-auth-0.4.2.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/annotation/javax.annotation-api-1.3.2.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/google/guava-18.0.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-1.9.10.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.9.10.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/mockito/mockito-core-3.0.0.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.6.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -11,6 +11,7 @@ VERSION: 0.1.0 (Release TDB)
   has been removed.
 * JsonServerServlet automatic provenance generation has been removed.
 * Java required version is now 1.8.
+* JsonServerServlet now has a constructor more suited for embedding the servlet as a library.
 
 VERSION: 0.0.25 (Release 11/15/2018)
 ------------------------------------

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,6 +4,14 @@ OVERVIEW
 -----------------------------------------
 Repo for code shared between Java services.
 
+VERSION: 0.1.0 (Release TDB)
+----------------------------
+
+* JsonServerServlet method dispatch to the Narrative Job Service (via *_async and *_check) methods
+  has been removed.
+* JsonServerServlet automatic provenance generation has been removed.
+* Java required version is now 1.8.
+
 VERSION: 0.0.25 (Release 11/15/2018)
 ------------------------------------
 - The SDK logger now reads an environment variable, `KB_SDK_LOGGER_TARGET_PACKAGE`,

--- a/build.xml
+++ b/build.xml
@@ -61,7 +61,16 @@
     <include name="javassist/javassist-3.18.2.jar"/>
     <include name="joda/joda-time-2.2.jar"/>
     <include name="annotation/javax.annotation-api-1.3.2.jar"/>
+    <!-- mockito and dependencies -->
+    <include name="mockito/mockito-core-3.0.0.jar"/>
+    <include name="bytebuddy/byte-buddy-1.9.10.jar"/>
+    <include name="bytebuddy/byte-buddy-agent-1.9.10.jar"/>
+    <include name="objenesis/objenesis-2.6.jar"/>
+    <!-- more test dependencies -->
+    <include name="google/guava-18.0.jar"/>
   </fileset>
+
+  <!-- TODO separate out test dependencies -->
 
   <path id="compile.classpath">
     <fileset refid="lib"/>

--- a/build.xml
+++ b/build.xml
@@ -84,7 +84,7 @@
   <target name="compile" depends="init, definejarfile" description="compile the source">
     <!-- Compile class files-->
     <javac destdir="${classes}" includeantruntime="false"
-      debug="true" classpathref="compile.classpath" target="1.7" source="1.7">
+      debug="true" classpathref="compile.classpath" target="1.8" source="1.8">
       <src path="${src}"/>
       <exclude name="us/kbase/common/performance/**"/>
     </javac>
@@ -105,7 +105,7 @@
     <javadoc access="protected" author="false" classpathref="compile.classpath"
       destdir="${docs}/javadoc" nodeprecated="false" nodeprecatedlist="false"
       noindex="false" nonavbar="false" notree="false"
-      source="1.7" splitindex="true" use="true" version="true">
+      source="1.8" splitindex="true" use="true" version="true">
       <link href="http://download.oracle.com/javase/7/docs/api/"/>
     <packageset dir="src" defaultexcludes="yes">
       <include name="**"/>

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -151,7 +151,7 @@ public class JsonServerServlet extends HttpServlet {
 	/** Create a new Servlet.
 	 * @param specServiceName the name of this server.
 	 */
-	public JsonServerServlet(String specServiceName) {
+	public JsonServerServlet(final String specServiceName) {
 		this.specServiceName = specServiceName;
 		this.mapper = new ObjectMapper().registerModule(new JacksonTupleModule());
 		this.rpcCache = new HashMap<String, Method>();

--- a/src/us/kbase/common/service/JsonServerServlet.java
+++ b/src/us/kbase/common/service/JsonServerServlet.java
@@ -1,5 +1,7 @@
 package us.kbase.common.service;
 
+import static java.util.Objects.requireNonNull;
+
 import us.kbase.auth.AuthConfig;
 import us.kbase.auth.AuthException;
 import us.kbase.auth.AuthToken;
@@ -61,7 +63,7 @@ public class JsonServerServlet extends HttpServlet {
 	private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final String X_REAL_IP = "X-Real-IP";
 	private ObjectMapper mapper;
-	private Map<String, Method> rpcCache;
+	private final Map<String, Method> rpcCache = new HashMap<>();
 	public static final int LOG_LEVEL_ERR = JsonServerSyslog.LOG_LEVEL_ERR;
 	public static final int LOG_LEVEL_INFO = JsonServerSyslog.LOG_LEVEL_INFO;
 	public static final int LOG_LEVEL_DEBUG = JsonServerSyslog.LOG_LEVEL_DEBUG;
@@ -84,8 +86,8 @@ public class JsonServerServlet extends HttpServlet {
 	//set to 'true' for true, anything else for false.
 	private static final String CONFIG_AUTH_SERVICE_ALLOW_INSECURE_URL_PARAM =
 			"auth-service-url-allow-insecure";
-	private final ConfigurableAuthService auth;
-	protected Map<String, String> config = new HashMap<String, String>();
+	private final AuthenticationHandler auth;
+	protected Map<String, String> config; // would like to be final but might break stuff
 	private Server jettyServer = null;
 	private Integer jettyPort = null;
 	private boolean startupFailed = false;
@@ -94,6 +96,7 @@ public class JsonServerServlet extends HttpServlet {
 	private File rpcDiskCacheTempDir = null;
 	private final String specServiceName;
 	private String serviceVersion = null;
+	private final boolean trustX_IPHeaders;
 		
 	private final static DateTimeFormatter DATE_FORMATTER =
 			DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZoneUTC();
@@ -148,26 +151,101 @@ public class JsonServerServlet extends HttpServlet {
 		this.startupFailed = true;
 	}
 	
-	/** Create a new Servlet.
+	/** Create a new Servlet with default authentication handling.
+	 * The servlet will read a *.ini based configuration file, where the file location is
+	 * specified by the environment variable or system property KB_DEPLOYMENT_CONFIG. The system
+	 * property takes precedence.
+	 * 
+	 * The section of the ini file that the server will read is designated by, in order of
+	 * precedence:
+	 * * The system property KB_SERVICE_NAME
+	 * * The environment variable KB_SERVICE_NAME
+	 * * The specServiceName parameter with any characters including and after the first colon (:)
+	 *   removed.
+	 * 
+	 * The configuration read is available in the {@link #config} variable.
+	 * 
+	 * The server treats the following properties of the ini file section specially:
+	 * * auth-service-url: the URL of the KBase legacy endpoint for the KBase auth server
+	 *   (https://github.com/kbase/auth2).
+	 * * auth-service-url-allow-insecure: set to "true" (no quotes) to allow auth-service-url
+	 *   to be insecure. Do not do this in production or anywhere else you don't want tokens
+	 *   to leak.
+	 * * dont-trust-x-ip-headers or dont_trust_x_ip_headers: if either is true, the
+	 *   X-Forwarded-For and X-Real-IP headers will be ignored when determining the requester's
+	 *   IP address. See ({@link #getIpAddress(HttpServletRequest, boolean)} for more information.
+	 *   
+	 * For logging properties, refer to {@link JsonServerSyslog}.
+	 * 
 	 * @param specServiceName the name of this server.
 	 */
 	public JsonServerServlet(final String specServiceName) {
 		this.specServiceName = specServiceName;
 		this.mapper = new ObjectMapper().registerModule(new JacksonTupleModule());
-		this.rpcCache = new HashMap<String, Method>();
-		for (Method m : getClass().getMethods()) {
-			if (m.isAnnotationPresent(JsonServerMethod.class)) {
-				JsonServerMethod ann = m.getAnnotation(JsonServerMethod.class);
-				rpcCache.put(ann.rpc(), m);
-			}
-		}
-		
+		setUpMethodCache();
 		sysLogger = new JsonServerSyslog(getServiceName(specServiceName),
 				KB_DEP, LOG_LEVEL_INFO, false);
 		userLogger = new JsonServerSyslog(sysLogger, true);
 		config = getConfig(specServiceName, sysLogger);
 		auth = getAuth(config);
+		this.trustX_IPHeaders =
+				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS)) &&
+				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS2));
+		//TODO TEST with default authentication. Needs auth server test mode running
+	}
+
+	private void setUpMethodCache() {
+		for (final Method m : getClass().getMethods()) {
+			if (m.isAnnotationPresent(JsonServerMethod.class)) {
+				JsonServerMethod ann = m.getAnnotation(JsonServerMethod.class);
+				rpcCache.put(ann.rpc(), m);
+			}
+		}
+	}
+	
+	/** A handler for authentication information. Given a token, it returns the validated token
+	 * and username of the user.
+	 *
+	 */
+	public interface AuthenticationHandler {
 		
+		/** Validate a token.
+		 * @param token the token to be validated.
+		 * @return the validated token.
+		 * @throws IOException if an IO error occurs.
+		 * @throws AuthException if the token could not be validated.
+		 */
+		AuthToken validateToken(String token) throws IOException, AuthException;
+	}
+	
+	/** Create a new Servlet with custom authentication handling. 
+	 * 
+	 * The servlet does not read from any configuration files, and the {@link #config} variable
+	 * will be an empty map.
+	 * 
+	 * @param specServiceName the name of this server, used for setting the service name when
+	 * logging. Overridden by the KB_SERVICE_NAME system property and environment variable.
+	 * @param auth the authentication handler.
+	 * @param trustX_IPHeaders true to trust the X-Forwarded-For and X-Real-IP headers (see
+	 * {@link #getIpAddress(HttpServletRequest, boolean)})
+	 */
+	public JsonServerServlet(
+			final String specServiceName,
+			final AuthenticationHandler auth,
+			final boolean trustX_IPHeaders) {
+		//TODO NOW use repackaged jackson jars
+		//TODO CODE hopefully remove rpc context?
+		// may also need to repackage jetty jar, not sure. I hope not
+		this.specServiceName = specServiceName;
+		this.auth = requireNonNull(auth, "auth");
+		this.trustX_IPHeaders = trustX_IPHeaders;
+		this.mapper = new ObjectMapper().registerModule(new JacksonTupleModule());
+		setUpMethodCache();
+		
+		sysLogger = new JsonServerSyslog(getServiceName(specServiceName),
+				null, LOG_LEVEL_INFO, false);
+		userLogger = new JsonServerSyslog(sysLogger, true);
+		config = new HashMap<>(); // this should really be immutable...
 	}
 	
 	protected String getAuthUrlFromConfig(final Map<String, String> config) {
@@ -178,7 +256,20 @@ public class JsonServerServlet extends HttpServlet {
 		return config.get(CONFIG_AUTH_SERVICE_ALLOW_INSECURE_URL_PARAM);
 	}
 	
-	protected ConfigurableAuthService getAuth(final Map<String, String> config) {
+	private class DefaultAuthenticationHandler implements AuthenticationHandler {
+		
+		private final ConfigurableAuthService auth;
+
+		private DefaultAuthenticationHandler(final ConfigurableAuthService auth) {
+			this.auth = auth;
+		}
+		
+		public AuthToken validateToken(final String token) throws IOException, AuthException {
+			return auth.validateToken(token);
+		}
+	}
+	
+	protected AuthenticationHandler getAuth(final Map<String, String> config) {
 		final String authURL = getAuthUrlFromConfig(config);
 		final AuthConfig c = new AuthConfig();
 		if (authURL != null && !authURL.isEmpty()) {
@@ -196,7 +287,7 @@ public class JsonServerServlet extends HttpServlet {
 			}
 		}
 		try {
-			return new ConfigurableAuthService(c);
+			return new DefaultAuthenticationHandler(new ConfigurableAuthService(c));
 		} catch (IOException e) {
 			startupFailed();
 			sysLogger.log(LOG_LEVEL_ERR, getClass().getName(),
@@ -246,7 +337,7 @@ public class JsonServerServlet extends HttpServlet {
 					"The configuration file " + deploy + " has no section " +
 					serviceName);
 		}
-		return config;
+		return config; // should really be immutable...
 	}
 
 	protected String getDefaultServiceName() {
@@ -254,6 +345,7 @@ public class JsonServerServlet extends HttpServlet {
 	}
 	
 	protected static String getServiceName(final String defaultServiceName) {
+		//TODO CODE test null or empty here
 		if (defaultServiceName == null) {
 			throw new NullPointerException("service name cannot be null");
 		}
@@ -262,8 +354,7 @@ public class JsonServerServlet extends HttpServlet {
 		if (serviceName == null) {
 			serviceName = defaultServiceName;
 			if (serviceName.contains(":"))
-				serviceName = serviceName.substring(
-						0, serviceName.indexOf(':')).trim();
+				serviceName = serviceName.substring(0, serviceName.indexOf(':')).trim();
 		}
 		return serviceName;
 	}
@@ -325,7 +416,7 @@ public class JsonServerServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		JsonServerSyslog.RpcInfo info = JsonServerSyslog.getCurrentRpcInfo().reset();
-		info.setIp(getIpAddress(request, config));
+		info.setIp(getIpAddress(request, trustX_IPHeaders));
 		response.setContentType(APP_JSON);
 		OutputStream output = response.getOutputStream();
 		JsonServerSyslog.getCurrentRpcInfo().reset();
@@ -354,7 +445,7 @@ public class JsonServerServlet extends HttpServlet {
 	@Override
 	protected void doPost(HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 		checkMemoryForRpc();
-		String remoteIp = getIpAddress(request, config);
+		String remoteIp = getIpAddress(request, trustX_IPHeaders);
 		setupResponseHeaders(request, response);
 		OutputStream output = response.getOutputStream();
 		ResponseStatusSetter respStatus = new ResponseStatusSetter() {
@@ -535,8 +626,9 @@ public class JsonServerServlet extends HttpServlet {
 				if (token != null || !rpcMethod.getAnnotation(JsonServerMethod.class).authOptional()) {
 					try {
 						userProfile = validateToken(token);
-						if (userProfile != null)
+						if (userProfile != null) {
 							info.setUser(userProfile.getUserName());
+						}
 					} catch (Throwable ex) {
 						writeError(response, -32400, "Token validation failed: " + ex.getMessage(), ex, output);
 						return;
@@ -633,22 +725,18 @@ public class JsonServerServlet extends HttpServlet {
 	 * 1. The first address in X-Forwarded-For
 	 * 2. X-Real-IP
 	 * 3. The remote address.
-	 * If dont_trust_x_ip_headers or dont-trust-x-ip-headers is set to "true"
-	 * in the configuration, the remote address is returned.
 	 * @param request the HTTP request
-	 * @param config the server configuration as returned by getConfig().
+	 * @param trustX_IPHeaders if true, always return the remote address, ignoring any other
+	 * headers.
 	 * @return the IP address of the client.
 	 */
 	public static String getIpAddress(
 			final HttpServletRequest request,
-			final Map<String, String> config) {
+			final boolean trustX_IPHeaders) {
 		final String xFF = request.getHeader(X_FORWARDED_FOR);
 		final String realIP = request.getHeader(X_REAL_IP);
-		final boolean trustXHeaders =
-				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS)) &&
-				!STRING_TRUE.equals(config.get(DONT_TRUST_X_IP_HEADERS2));
 
-		if (trustXHeaders) {
+		if (trustX_IPHeaders) {
 			if (xFF != null && !xFF.isEmpty()) {
 				return xFF.split(",")[0].trim();
 			}

--- a/src/us/kbase/common/test/TestCommon.java
+++ b/src/us/kbase/common/test/TestCommon.java
@@ -1,0 +1,306 @@
+package us.kbase.common.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.AppenderBase;
+import us.kbase.common.test.TestException;
+
+public class TestCommon {
+	
+	public static final String LONG101;
+	public static final String LONG1001;
+	static {
+		final StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 100; i++) {
+			sb.append("a");
+		}
+		final String s100 = sb.toString();
+		final StringBuilder sb2 = new StringBuilder();
+		for (int i = 0; i < 10; i++) {
+			sb2.append(s100);
+		}
+		LONG101 = s100 + "a";
+		LONG1001 = sb2.toString() + "a";
+	}
+	
+	public static void stfuLoggers() {
+		((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+				.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
+			.setLevel(ch.qos.logback.classic.Level.OFF);
+		java.util.logging.Logger.getLogger("com.mongodb")
+			.setLevel(java.util.logging.Level.OFF);
+	}
+	
+	public static void printJava() {
+		System.out.println("Java: " +
+				System.getProperty("java.runtime.version"));
+	}
+
+	public static void assertExceptionCorrect(
+			final Throwable got,
+			final Throwable expected) {
+		assertThat("incorrect exception. trace:\n" +
+				ExceptionUtils.getStackTrace(got),
+				got.getLocalizedMessage(),
+				is(expected.getLocalizedMessage()));
+		assertThat("incorrect exception type", got, instanceOf(expected.getClass()));
+	}
+	
+	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html
+	@SuppressWarnings("unchecked")
+	public static Map<String, String> getenv()
+			throws NoSuchFieldException, SecurityException,
+			IllegalArgumentException, IllegalAccessException {
+		Map<String, String> unmodifiable = System.getenv();
+		Class<?> cu = unmodifiable.getClass();
+		Field m = cu.getDeclaredField("m");
+		m.setAccessible(true);
+		return (Map<String, String>) m.get(unmodifiable);
+	}
+	
+	@SafeVarargs
+	public static <T> Set<T> set(T... objects) {
+		return new HashSet<T>(Arrays.asList(objects));
+	}
+	
+	public static Instant inst(final long epoch) {
+		return Instant.ofEpochMilli(epoch);
+	}
+	
+	public static class LogEvent {
+		
+		public final Level level;
+		public final String message;
+		public final String className;
+		public final Throwable ex;
+		
+		public LogEvent(final Level level, final String message, final Class<?> clazz) {
+			this.level = level;
+			this.message = message;
+			this.className = clazz.getName();
+			ex = null;
+		}
+
+		public LogEvent(final Level level, final String message, final String className) {
+			this.level = level;
+			this.message = message;
+			this.className = className;
+			ex = null;
+		}
+		
+		public LogEvent(
+				final Level level,
+				final String message,
+				final Class<?> clazz,
+				final Throwable ex) {
+			this.level = level;
+			this.message = message;
+			this.className = clazz.getName();
+			this.ex = ex;
+		}
+		
+		public LogEvent(
+				final Level level,
+				final String message,
+				final String className,
+				final Throwable ex) {
+			this.level = level;
+			this.message = message;
+			this.className = className;
+			this.ex = ex;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder builder = new StringBuilder();
+			builder.append("LogEvent [level=");
+			builder.append(level);
+			builder.append(", message=");
+			builder.append(message);
+			builder.append(", className=");
+			builder.append(className);
+			builder.append(", ex=");
+			builder.append(ex);
+			builder.append("]");
+			return builder.toString();
+		}
+	}
+	
+	public static List<ILoggingEvent> setUpSLF4JTestLoggerAppender(final String package_) {
+		final Logger authRootLogger = (Logger) LoggerFactory.getLogger(package_);
+		authRootLogger.setAdditive(false);
+		authRootLogger.setLevel(Level.ALL);
+		final List<ILoggingEvent> logEvents = new LinkedList<>();
+		final AppenderBase<ILoggingEvent> appender =
+				new AppenderBase<ILoggingEvent>() {
+			@Override
+			protected void append(final ILoggingEvent event) {
+				logEvents.add(event);
+			}
+		};
+		appender.start();
+		authRootLogger.addAppender(appender);
+		return logEvents;
+	}
+	
+	public static void assertLogEventsCorrect(
+			final List<ILoggingEvent> logEvents,
+			final LogEvent... expectedlogEvents) {
+		
+		assertThat("incorrect log event count for list: " + logEvents, logEvents.size(),
+				is(expectedlogEvents.length));
+		final Iterator<ILoggingEvent> iter = logEvents.iterator();
+		for (final LogEvent le: expectedlogEvents) {
+			final ILoggingEvent e = iter.next();
+			assertThat("incorrect log level", e.getLevel(), is(le.level));
+			assertThat("incorrect originating class", e.getLoggerName(), is(le.className));
+			assertThat("incorrect message", e.getFormattedMessage(), is(le.message));
+			final IThrowableProxy err = e.getThrowableProxy();
+			if (err != null) {
+				if (le.ex == null) {
+					fail(String.format("Logged exception where none was expected: %s %s %s",
+							err.getClassName(), err.getMessage(), le));
+				} else {
+					assertThat("incorrect error class for event " + le, err.getClassName(),
+							is(le.ex.getClass().getName()));
+					assertThat("incorrect error message for event " + le, err.getMessage(),
+							is(le.ex.getMessage()));
+				}
+			} else if (le.ex != null) { 
+				fail("Expected exception but none was logged: " + le);
+			}
+		}
+	}
+	
+	public static void createAuthUser(
+			final URL authURL,
+			final String userName,
+			final String displayName)
+			throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/user");
+		final HttpURLConnection conn = getPOSTConnection(target);
+
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"user", userName,
+				"display", displayName)));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+	}
+
+	private static HttpURLConnection getPOSTConnection(final URL target) throws Exception {
+		return getConnection("POST", target);
+	}
+	
+	private static HttpURLConnection getPUTConnection(final URL target) throws Exception {
+		return getConnection("PUT", target);
+	}
+	
+	private static HttpURLConnection getConnection(final String verb, final URL target)
+			throws Exception {
+		final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+		conn.setRequestMethod(verb);
+		conn.setRequestProperty("content-type", "application/json");
+		conn.setRequestProperty("accept", "application/json");
+		conn.setDoOutput(true);
+		return conn;
+	}
+
+	private static void checkForError(final HttpURLConnection conn) throws IOException {
+		final int rescode = conn.getResponseCode();
+		if (rescode < 200 || rescode >= 300) {
+			System.out.println("Response code: " + rescode);
+			String err = IOUtils.toString(conn.getErrorStream()); 
+			System.out.println(err);
+			if (err.length() > 200) {
+				err = err.substring(0, 200);
+			}
+			throw new TestException(err);
+		}
+	}
+
+	public static String createLoginToken(final URL authURL, String user) throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/token");
+		final HttpURLConnection conn = getPOSTConnection(target);
+
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"user", user,
+				"type", "Login")));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+		final String out = IOUtils.toString(conn.getInputStream());
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> resp = new ObjectMapper().readValue(out, Map.class);
+		return (String) resp.get("token");
+	}
+	
+	public static void createCustomRole(
+			final URL authURL,
+			final String role,
+			final String description)
+			throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/customroles");
+		final HttpURLConnection conn = getPOSTConnection(target);
+
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"id", role,
+				"desc", description)));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+	}
+	
+	// will zero out standard roles, which don't do much in test mode
+	public static void setUserRoles(
+			final URL authURL,
+			final String user,
+			final List<String> customRoles)
+			throws Exception {
+		final URL target = new URL(authURL.toString() + "/api/V2/testmodeonly/userroles");
+		final HttpURLConnection conn = getPUTConnection(target);
+		
+		final DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
+		writer.writeBytes(new ObjectMapper().writeValueAsString(ImmutableMap.of(
+				"user", user,
+				"customroles", customRoles)));
+		writer.flush();
+		writer.close();
+
+		checkForError(conn);
+	}
+}

--- a/src/us/kbase/common/test/service/HttpServletRequestMock.java
+++ b/src/us/kbase/common/test/service/HttpServletRequestMock.java
@@ -25,7 +25,11 @@ public class HttpServletRequestMock implements HttpServletRequest {
 	}
 	
 	public void setHeader(String key, String value) {
-		headers.put(key, value);
+		if (value == null) {
+			headers.remove(key);
+		} else {
+			headers.put(key, value);
+		}
 	}
 	
 	@Override

--- a/src/us/kbase/common/test/service/JsonServerServletPublicMethodsTest.java
+++ b/src/us/kbase/common/test/service/JsonServerServletPublicMethodsTest.java
@@ -31,50 +31,33 @@ public class JsonServerServletPublicMethodsTest {
 
 	@Test
 	public void ipAddress() throws Exception {
-		Map<String, String> config = new HashMap<String, String>();
 		HttpServletRequestMock req = new HttpServletRequestMock();
 		req.setIpAddress("000.000.000.001");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
+				req, true), is("000.000.000.001"));
 		
 		req.setHeader("X-Real-IP", "");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
+				req, true), is("000.000.000.001"));
 		
 		req.setHeader("X-Real-IP", "000.000.000.002");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.002"));
+				req, true), is("000.000.000.002"));
 		
 		req.setHeader("X-Forwarded-For", "");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.002"));
+				req, true), is("000.000.000.002"));
 		
 		req.setHeader("X-Forwarded-For", "000.000.000.003 , somecrap");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.003"));
+				req, true), is("000.000.000.003"));
 		
-		config.put("dont_trust_x_ip_headers", "false");
-		config.put("dont-trust-x-ip-headers", "tru");
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.003"));
+				req, false), is("000.000.000.001"));
 		
-		config.put("dont-trust-x-ip-headers", "true");
+		req.setHeader("X-Forwarded-For", null);
 		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
-		
-		config.put("dont_trust_x_ip_headers", "true");
-		config.put("dont-trust-x-ip-headers", "tru");
-		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
-		
-		config.remove("X-Forwarded-For");
-		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
-		
-		config.put("dont_trust_x_ip_headers", "tru");
-		config.put("dont-trust-x-ip-headers", "true");
-		assertThat("correct IP address", JsonServerServlet.getIpAddress(
-				req, config), is("000.000.000.001"));
+				req, false), is("000.000.000.001"));
 	}
 	
 	//http://quirkygba.blogspot.com/2009/11/setting-environment-variables-in-java.html

--- a/src/us/kbase/common/test/service/JsonServerServletTest.java
+++ b/src/us/kbase/common/test/service/JsonServerServletTest.java
@@ -1,0 +1,231 @@
+package us.kbase.common.test.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.JsonServerMethod;
+import us.kbase.common.service.JsonServerServlet;
+import us.kbase.common.service.JsonServerServlet.AuthenticationHandler;
+import us.kbase.common.service.RpcContext;
+import us.kbase.common.test.TestCommon;
+
+public class JsonServerServletTest {
+	
+	// TODO TEST more tests, more complete tests. Current tests are very basic happy path and don't check logging, etc.
+	
+	@SuppressWarnings("serial")
+	public class FakeServer extends JsonServerServlet {
+		
+		public int onRpcMethodDoneCalls = 0;
+		public List<AuthToken> tokens = new ArrayList<>();
+
+		public FakeServer(
+				final String specServiceName,
+				final AuthenticationHandler auth,
+				final boolean trustX_IPHeaders) {
+			super(specServiceName, auth, trustX_IPHeaders);
+		}
+		
+		@JsonServerMethod(rpc = "FakeServer.do_the_thing1", async=true)
+		public Integer doTheThing1(Integer input, RpcContext jsonRpcContext) throws Exception {
+			return input + 1;
+		}
+		
+		@JsonServerMethod(rpc = "FakeServer.do_the_thing2", authOptional=true, async=true)
+		public Integer doTheThing2(Integer input, AuthToken authPart, RpcContext jsonRpcContext)
+				throws Exception {
+			tokens.add(authPart);
+			return input + 2;
+		}
+		
+		@JsonServerMethod(rpc = "FakeServer.do_the_thing3", authOptional=false, async=true)
+		public Integer doTheThing3(Integer input, AuthToken authPart, RpcContext jsonRpcContext)
+				throws Exception {
+			tokens.add(authPart);
+			return input + 3;
+		}
+		
+		@Override
+		public void doPost(HttpServletRequest request, final HttpServletResponse response)
+				throws ServletException, IOException {
+			super.doPost(request, response);
+		}
+		
+		@Override
+		public void onRpcMethodDone() {
+			onRpcMethodDoneCalls++;
+		}
+		
+		@Override
+		public String getDefaultServiceName() {
+			return super.getDefaultServiceName();
+		}
+		
+		public Map<String, String> getConfig() {
+			return super.config;
+		}
+		
+	}
+	
+	private class ServletInputStreamWrapper extends ServletInputStream {
+		
+		private final InputStream in;
+
+		public ServletInputStreamWrapper(final InputStream in) {
+			this.in = in;
+		}
+
+		@Override
+		public int read() throws IOException {
+			return in.read();
+		}
+	}
+	
+	private class ServletOutputStreamWrapper extends ServletOutputStream {
+
+		private final OutputStream out;
+
+		public ServletOutputStreamWrapper(final OutputStream out) {
+			this.out = out;
+		}
+		
+		@Override
+		public void write(int b) throws IOException {
+			out.write(b);
+		}
+	}
+	
+	@Test
+	public void constructServerFail() throws Exception {
+		final AuthenticationHandler ah = mock(AuthenticationHandler.class);
+		
+		constructFail(null, ah, new NullPointerException("service name cannot be null"));
+		constructFail("f", null, new NullPointerException("auth"));
+	}
+	
+	private void constructFail(
+			final String name,
+			final AuthenticationHandler auth,
+			final Exception expected) {
+		try {
+			new FakeServer(name, auth, true);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+		
+	}
+	
+	@Test
+	public void postWithNoAuth() throws Exception {
+		post("FakeServer.do_the_thing1", 7, null, false);
+	}
+	
+	@Test
+	public void postWithOptionalAuthNoToken() throws Exception {
+		post("FakeServer.do_the_thing2", 8, null, true);
+	}
+	
+	
+	@Test
+	public void postWithOptionalAuthWithToken() throws Exception {
+		post("FakeServer.do_the_thing2", 8, new AuthToken("token", "foo"), true);
+	}
+	
+	@Test
+	public void postWithRequiredAuthn() throws Exception {
+		post("FakeServer.do_the_thing3", 9, new AuthToken("token", "foo"), true);
+	}
+	
+	private void post(
+			final String method,
+			final int result,
+			final AuthToken token,
+			final boolean expectToken)
+			throws Exception {
+		final AuthenticationHandler ah = mock(AuthenticationHandler.class);
+		final HttpServletRequest req = mock(HttpServletRequest.class);
+		final HttpServletResponse resp = mock(HttpServletResponse.class);
+		
+		// note the trust x ip headers arg is untested - only affects logging the ip address
+		final FakeServer fs = new FakeServer("servName", ah, false);
+		
+		assertThat("incorrect service name", fs.getDefaultServiceName(), is("servName"));
+		assertThat("incorrect config", fs.getConfig(), is(Collections.emptyMap()));
+		
+		when(req.getRemoteAddr()).thenReturn("123.456.789.123");
+		
+		if (token != null) {
+			// caps important here since it's a mock
+			when(req.getHeader("Authorization")).thenReturn(token.getToken());
+			when(ah.validateToken(token.getToken())).thenReturn(token);
+		}
+		
+		final Map<String, Object> packge = ImmutableMap.of(
+				"method", method,
+				"version", "1.1",
+				"id", 56,
+				"params", Arrays.asList(6));
+		
+		final InputStream input = new ByteArrayInputStream(
+				new ObjectMapper().writeValueAsBytes(packge));
+		
+		final ByteArrayOutputStream output = new ByteArrayOutputStream();
+		
+		when(req.getInputStream()).thenReturn(new ServletInputStreamWrapper(input));
+		
+		when(resp.getOutputStream()).thenReturn(new ServletOutputStreamWrapper(output));
+		
+		fs.doPost(req, resp);
+		
+		final Map<String, Object> response = new ObjectMapper().readValue(
+				output.toByteArray(), new TypeReference<Map<String, Object>>(){});
+		assertThat("incorrect response", response,
+				is(ImmutableMap.of("version", "1.1", "result", Arrays.asList(result))));
+		if (expectToken) {
+			assertThat("incorrect tokens", fs.tokens, is(Arrays.asList(token)));
+		} else {
+			assertThat("incorrect tokens", fs.tokens, is(Collections.emptyList()));
+		}
+		
+		verify(resp, never()).setStatus(anyInt()); // status only set on error
+		verify(resp).setHeader("Access-Control-Allow-Origin", "*");
+		verify(resp).setHeader("Access-Control-Allow-Headers", "authorization");
+		verify(resp).setContentType("application/json");
+		if (token == null) {
+			verifyZeroInteractions(ah);
+		}
+		assertThat("incorrect on rpc done calls", fs.onRpcMethodDoneCalls, is(1));
+	}
+}


### PR DESCRIPTION
The only constructor for the JsonServerServlet assumes it's running on
its own - it parses a config file, sets up its own auth, etc.

Add a constructor where the server build is more controllable and
therefore the server is more embeddable.

Allowing the logger to be specified might also be useful, but so much of
the logger api is used that might be tricky.

Also add some happy path tests.