### PR TITLE
Fix bugs in the JSON tokenizer used by JAVA SDK apps/services

### DIFF
--- a/src/us/kbase/common/service/JsonTokenStream.java
+++ b/src/us/kbase/common/service/JsonTokenStream.java
@@ -276,6 +276,8 @@ public class JsonTokenStream extends JsonParser {
 			lastToken = nextToken();
 		List<String> ret = new ArrayList<String>();
 		int size = path.size() - 1;
+		// this is a bug. If the path is empty and this method is called 
+		// you'll get an index exception
 		for (int i = 0; i < size; i++) {
 			Object item = path.get(i);
 			ret.add(String.valueOf(item));
@@ -508,9 +510,11 @@ public class JsonTokenStream extends JsonParser {
 	}
 	
 	private void debug() {
-		StackTraceElement el = Thread.currentThread().getStackTrace()[2];
-		try {
-			System.out.println("Calling JsonTokenStream." + el.getMethodName());
+	 	StackTraceElement el2 = Thread.currentThread().getStackTrace()[2];
+	 	StackTraceElement el3 = Thread.currentThread().getStackTrace()[3];
+	 	try {
+			System.out.println("Calling JsonTokenStream." + el2.getMethodName() + " from " +
+					el3.getClassName() + "." + el3.getMethodName() + ":" + el3.getLineNumber());
 		} catch (Exception ex) {
 			throw new IllegalStateException(ex);
 		}
@@ -752,7 +756,12 @@ public class JsonTokenStream extends JsonParser {
 	@Override
 	public JsonToken nextValue() throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextValue();
+		// copied from com.fasterxml.jackson.core.base.ParserMinimalBase
+		JsonToken t = nextToken();
+		if (t == JsonToken.FIELD_NAME) {
+			t = nextToken();
+		}
+		return t;
 	}
 	
 	@Override
@@ -929,32 +938,34 @@ public class JsonTokenStream extends JsonParser {
 	@Override
 	public Boolean nextBooleanValue() throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextBooleanValue();
+		return super.nextBooleanValue();
 	}
+
+	// TODO Override String nextFieldName() when updating jars, added in 2.5
 	
 	@Override
-	public boolean nextFieldName(SerializableString arg0) throws IOException,
-			JsonParseException {
+	public boolean nextFieldName(final SerializableString str)
+			throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextFieldName(arg0);
+		return super.nextFieldName(str);
 	}
 	
 	@Override
 	public int nextIntValue(int arg0) throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextIntValue(arg0);
+		return super.nextIntValue(arg0);
 	}
 	
 	@Override
 	public long nextLongValue(long arg0) throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextLongValue(arg0);
+		return super.nextLongValue(arg0);
 	}
 	
 	@Override
 	public String nextTextValue() throws IOException, JsonParseException {
 		if (debug) debug();
-		return getInner().nextTextValue();
+		return super.nextTextValue();
 	}
 	
 	@Override


### PR DESCRIPTION
SDK Java based apps, services, and clients use a customized JSON tokenizer
from this repo (we'll call it JTS). The tokenizer wraps an inner Jackson
tokenizer (inner). The JTS keeps track of the current path in the JSON
in its own state.

The bugs result when one of several helper methods (the next*() methods)
are called on JTS. These methods delegate to the inner tokenizer and
therefore the state stored in JTS is not updated even though the token
stream provided by inner is advanced. This causes lots of weird errors
and can make the tokenizer unusable in the context of SDK processes.

The fix is to make the helper methods delegate to the JTS superclass
instead of the inner tokenizer. The superclass methods all call
nextToken() under the hood, which is overridden in JTS, and ensures the
state is updated correctly.

In one case, the super class method was abstract, so the implementation
was copied from MinimalParserBase, a subclass of the superclass.

I assume that no code paths actually used the helper methods as we
haven't seen these failures in the field, as far as I know. However, I
did start seeing failures caused by these methods after updating Jackson
to 2.9.9, which is why I'm fixing these issues.