### PR TITLE
Update Jackson jars to 2.9.9

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,9 +10,6 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/commons-lang3-3.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/commons-logging-1.1.1.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/apache_commons/velocity-1.7.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-annotations-2.2.3.jar" sourcepath="/jars/lib/jars/jackson/jackson-annotations-2.2.3-sources.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-core-2.2.3.jar" sourcepath="/jars/lib/jars/jackson/jackson-core-2.2.3-sources.jar"/>
-	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-databind-2.2.3.jar" sourcepath="/jars/lib/jars/jackson/jackson-databind-2.2.3-sources.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/junit/junit-4.9.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mongo/mongo-java-driver-2.13.3.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/ini4j/ini4j-0.5.2.jar"/>
@@ -36,5 +33,16 @@
 	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.9.10.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/mockito/mockito-core-3.0.0.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.6.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-annotations-2.9.9.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-core-2.9.9.jar" sourcepath="/jars/lib/jars/jackson/jackson-core-2.9.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:platform:/resource/jars/lib/jars/jackson/jackson-core-2.9.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="/jars/lib/jars/jackson/jackson-databind-2.9.9.jar" sourcepath="/jars/lib/jars/jackson/jackson-databind-2.9.9-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:platform:/resource/jars/lib/jars/jackson/jackson-databind-2.9.9-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -16,6 +16,8 @@ VERSION: 0.1.0 (Release TBD)
 * The unused us.kbase.common.service.GwtTransformer class was removed.
 * The unused us.kbase.common.utils.JsonTreeGenerator class was removed.
 * Deprecated us.kbase.common.mongo.GetMongoDB class.
+* Fixed several bugs with token stream processing in JsonTokenStream.java.
+* Updated Jackson jars to v2.9.
 
 VERSION: 0.0.25 (Release 11/15/2018)
 ------------------------------------

--- a/build.xml
+++ b/build.xml
@@ -37,9 +37,9 @@
     <include name="apache_commons/commons-lang3-3.1.jar"/>
     <include name="junit/junit-4.9.jar"/>
     <include name="mongo/mongo-java-driver-2.13.3.jar"/>
-    <include name="jackson/jackson-core-2.2.3.jar"/>
-    <include name="jackson/jackson-databind-2.2.3.jar"/>
-    <include name="jackson/jackson-annotations-2.2.3.jar"/>
+    <include name="jackson/jackson-core-2.9.9.jar"/>
+    <include name="jackson/jackson-databind-2.9.9.jar"/>
+    <include name="jackson/jackson-annotations-2.9.9.jar"/>
     <include name="ini4j/ini4j-0.5.2.jar"/>
     <include name="jetty/jetty-all-7.0.0.jar"/>
     <include name="jna/jna-3.4.0.jar"/>

--- a/src/us/kbase/common/service/JacksonTupleModule.java
+++ b/src/us/kbase/common/service/JacksonTupleModule.java
@@ -35,6 +35,9 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
  */
 @SuppressWarnings("serial")
 public class JacksonTupleModule extends SimpleModule {
+	
+	// TODO CODE fix deprecations for Jackson and Java 11 updates
+	
 	public JacksonTupleModule() {
 		super(JacksonTupleModule.class.getSimpleName(), new Version(1, 0, 0, null, null, null));
 		setSerializers(new SimpleSerializers() {
@@ -193,7 +196,7 @@ public class JacksonTupleModule extends SimpleModule {
 
 		public static JsonNode valueToTree(ObjectCodec oc, Object fromValue) throws JsonProcessingException, IOException {
 			if (fromValue == null) return null;
-			TokenBuffer buf = new TokenBuffer(oc);
+			TokenBuffer buf = new TokenBuffer(oc, false);
 			oc.writeValue(buf, fromValue);
 			JsonParser jp = buf.asParser();
 			JsonNode result = oc.readTree(jp);
@@ -216,6 +219,8 @@ public class JacksonTupleModule extends SimpleModule {
 	
 	public static class UObjectDeserializer extends JsonDeserializer<UObject> {
 
+		//TODO NOW BUG this uses the same underlying jts for every uobject. Race condition.
+		
 		public UObject deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
 			if (p instanceof JsonTokenStream) {
 				JsonTokenStream jts = (JsonTokenStream)p;

--- a/src/us/kbase/common/service/JsonTokenStream.java
+++ b/src/us/kbase/common/service/JsonTokenStream.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonTokenId;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.TreeNode;
@@ -114,7 +115,8 @@ public class JsonTokenStream extends JsonParser {
 
 	}
 	
-	//TODO add a method like InputStream getInputStream() that otherwise behaves like writeJson()
+	//TODO CODE can this be simplified?
+	//TODO CODE add a method like InputStream getInputStream() that otherwise behaves like writeJson()
 	
 	/**
 	 * Create token stream for data source of one of the following types: File, String, byte[], JsonNode.
@@ -510,9 +512,9 @@ public class JsonTokenStream extends JsonParser {
 	}
 	
 	private void debug() {
-	 	StackTraceElement el2 = Thread.currentThread().getStackTrace()[2];
-	 	StackTraceElement el3 = Thread.currentThread().getStackTrace()[3];
-	 	try {
+		StackTraceElement el2 = Thread.currentThread().getStackTrace()[2];
+		StackTraceElement el3 = Thread.currentThread().getStackTrace()[3];
+		try {
 			System.out.println("Calling JsonTokenStream." + el2.getMethodName() + " from " +
 					el3.getClassName() + "." + el3.getMethodName() + ":" + el3.getLineNumber());
 		} catch (Exception ex) {
@@ -941,7 +943,11 @@ public class JsonTokenStream extends JsonParser {
 		return super.nextBooleanValue();
 	}
 
-	// TODO Override String nextFieldName() when updating jars, added in 2.5
+	@Override
+	public String nextFieldName() throws IOException, JsonParseException {
+		if (debug) debug();
+		return super.nextFieldName();
+	}
 	
 	@Override
 	public boolean nextFieldName(final SerializableString str)
@@ -1448,5 +1454,31 @@ public class JsonTokenStream extends JsonParser {
 	public interface DebugOpenCloseListener {
 		public void onStreamOpen(JsonTokenStream instance);
 		public void onStreamClosed(JsonTokenStream instance);
+	}
+
+	@Override
+	public int getCurrentTokenId() {
+		if (debug) debug();
+		final JsonToken current = getCurrentToken();
+		if (current == null) {
+			return JsonTokenId.ID_NO_TOKEN;
+		}
+		return current.id();
+	}
+
+	@Override
+	public boolean hasToken(final JsonToken t) {
+		if (debug) debug();
+		final JsonToken current = getCurrentToken();
+		if (current == null && (t == null || t == JsonToken.NOT_AVAILABLE)) {
+			return true;
+		}
+		return current == t;
+	}
+
+	@Override
+	public boolean hasTokenId(int id) {
+		if (debug) debug();
+		return getCurrentTokenId() == id;
 	}
 }

--- a/src/us/kbase/common/test/service/TupleTest.java
+++ b/src/us/kbase/common/test/service/TupleTest.java
@@ -60,7 +60,10 @@ public class TupleTest {
             Assert.fail("Error should happen");
         } catch (InvalidFormatException ex) {
             System.out.println(ex.getMessage());
-            Assert.assertTrue(ex.getMessage().contains("Can not construct instance of int from String value"));
+            Assert.assertTrue(ex.getMessage().contains(
+                   "Cannot deserialize value of type `java.lang.Integer` from String \"test\": " +
+                   "not a valid Integer value\n at [Source: (String)\"[\"test\",\"test\"]\"; " +
+                   "line: 1, column: 2]"));
         }
     }
 }


### PR DESCRIPTION
Required adding a few new abstract methods and overriding a method that
advances the token stream.